### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,19 @@
 ---
 
 ### Setup:
+This script is written for Windows, to run on Linux a few changes are required, specifically `\\` needing to be altered to `/`      
 If you don't provide your Plex URL and Plex token on line 2/3, the script will prompt you for them.   
-On running the script, it will prompt you which library you want to run the script on.
+On running the script, it will prompt you which libraries you want to run the script on.     
+Enter numbers, separated by commas, & those libraries will be processed, in that order, sequentially. e.g. `4,2,8,9`     
+It will then prompt for Posters, Backgrounds, Banners, Themes, Episode Art, & if you want to download all or just custom art.   
+ - Note: These do not currently work
 
 #### Movies
 - The poster will be exported to the same directory as the media file with the name `poster.png`
 
 #### TV Series
 - The show poster will be exported to the parent directory of the show with the name `poster.png`
-- The season covers will be exported to the parent directory of the show with the name `Season x.png`
+- The season covers will be exported to the parent directory of the show with the name `season##.png`
 - The episode title cards will be exported next to each file with the name matching the video file.
 
 At the end of the script, you can instantly run it again on another library by entering `y` (case sensitive)


### PR DESCRIPTION
* Added logging
  - Set to Max 10MB file `plex_poster_extract.log`
* Added ability to choose multiple libraries to be run in sequence
* Fixed issue that would cause the script to fault if an item did not have artwork set
* Working on ability to specify what to download, specifically to make it have an option to only download custom artwork not default Artwork. Not currently working
* Set Poster location & name for seasons as Per Plex guides in Root folder under `season##.png`
  - This prevents creating new folder `Season 2` if you have files in folder `Season 2 - Season Title`
* Set Episode posters to be created alongside episode files with the same name as the episode file but `.png` as the Extension